### PR TITLE
Fix multiline github links

### DIFF
--- a/site/js/docurium.js
+++ b/site/js/docurium.js
@@ -627,7 +627,7 @@ $(function() {
       if(line) {
         url += '#L' + line.toString()
         if(lineto) {
-          url += '-' + lineto.toString()
+          url += '-L' + lineto.toString()
         }
       } else {
         url += '#files'


### PR DESCRIPTION
Links to github files with multiple lines are not in the right format.
Should be according to: https://help.github.com/en/github/managing-your-work-on-github/creating-a-permanent-link-to-a-code-snippet